### PR TITLE
Fix flatJSON firing multiple times

### DIFF
--- a/src/bootstrap-table-flatJSON.js
+++ b/src/bootstrap-table-flatJSON.js
@@ -8,49 +8,20 @@
 (function ($) {
     'use strict';
 
-    var flatJSON = function (el, data) {
-        if (el.options.flat) {
-            el.options.data = sd.flatHelper(data);
-        }
-        if (el.options.sidePagination === 'server') {
-            el.data = el.options.data;
-        }
-    };
-
     $.extend($.fn.bootstrapTable.defaults, {
         flat: false
     });
 
     var BootstrapTable = $.fn.bootstrapTable.Constructor,
-        _initData = BootstrapTable.prototype.initData,
-        _init = BootstrapTable.prototype.init,
-        /*_load = BootstrapTable.prototype.load,*/
-        _initTable = BootstrapTable.prototype.initTable;
+        _initData = BootstrapTable.prototype.initData;
 
-    BootstrapTable.prototype.initData = function (data) {
-        _initData.apply(this, Array.prototype.slice.apply(arguments));
-        flatJSON(this, data === undefined ? this.options.data : data);
-    };
-
-    BootstrapTable.prototype.init = function () {
-        flatJSON(this, this.options.data);
-        _init.apply(this, Array.prototype.slice.apply(arguments));
-    };
-
-    BootstrapTable.prototype.initTable = function () {
-        flatJSON(this, this.options.data);
-        _initTable.apply(this, Array.prototype.slice.apply(arguments));
-    };
-
-    /*BootstrapTable.prototype.load = function (data) {
-        if (this.options.flat) {
+    BootstrapTable.prototype.initData = function (data, type) {
+        if( this.options.flat ){
+            data = data === undefined ? this.options.data : data;
             data = sd.flatHelper(data);
         }
-        if (this.options.sidePagination === 'server') {
-            this.data = this.options.data;
-        }
-        _load.apply(this, Array.prototype.slice.apply(arguments));
-    };*/
+        _initData.apply(this, [data, type]);
+    };
 
     //Main functions
     var sd = {


### PR DESCRIPTION
flatJSON is firing multiple times (`data` and `url` installs):
1) before `init()`
2) after `initData()` (called by `init()` || ajax request)
3) before `initTable()` (called by `init()` || ajax request)

This can be simplified by flattening the data prior to `initData()` and passing in as an argument.
- Loading data via html is irrelevant.
- Loading data via array will be flattened in `init()` (calls `initData()`)
- Loading data via url will be flattened in after the ajax request (calls `initData(data)`)

I tested this in a multitude of configurations, including `data-side-pagination="server"`. All seem to be working as expected.

In addition, this PR would fix issues https://github.com/djhvscf/bootstrap-table-flatJSON/issues/3 and https://github.com/djhvscf/bootstrap-table-flatJSON/issues/8.
